### PR TITLE
添加 attach 的支持

### DIFF
--- a/lib/open-amp/resource_table.c
+++ b/lib/open-amp/resource_table.c
@@ -37,7 +37,7 @@ static struct fw_resource_table __resource resource_table = {
 	.ver = 1,
 	.num = RSC_TABLE_NUM_ENTRY,
 	.offset = {
-
+		offsetof(struct fw_resource_table, ept_table),
 #if (CONFIG_OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF > 0)
 		offsetof(struct fw_resource_table, vdev),
 #endif
@@ -47,10 +47,15 @@ static struct fw_resource_table __resource resource_table = {
 #endif
 	},
 
+	.ept_table = {
+		.type = RSC_VENDOR_EPT_TABLE,
+		.num_of_epts = 0,
+	},
+
 #if (CONFIG_OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF > 0)
 	/* Virtio device entry */
 	.vdev = {
-		RSC_VDEV, VIRTIO_ID_RPMSG, 0, RPMSG_IPU_C0_FEATURES, 0, 0, 0,
+		RSC_VDEV, VIRTIO_ID_RPMSG, 2, RPMSG_IPU_C0_FEATURES, 0, 0, 0,
 		VRING_COUNT, {0, 0},
 	},
 

--- a/lib/open-amp/resource_table.h
+++ b/lib/open-amp/resource_table.h
@@ -7,6 +7,7 @@
 #ifndef RESOURCE_TABLE_H__
 #define RESOURCE_TABLE_H__
 
+#include <openamp/rpmsg.h>
 #include <openamp/remoteproc.h>
 #include <openamp/virtio.h>
 
@@ -28,9 +29,12 @@ extern "C" {
 #define VRING_BUFF_ADDRESS      -1  /* allocated by Master processor */
 #define VRING_ALIGNMENT         16  /* fixed to match with Linux constraint */
 
+#define RSC_VENDOR_EPT_TABLE    128 /* List of bound endpoints */
+
 #endif
 
 enum rsc_table_entries {
+	RSC_TABLE_EPT_TABLE_ENTRY,
 #if (CONFIG_OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF > 0)
 	RSC_TABLE_VDEV_ENTRY,
 #endif
@@ -40,12 +44,29 @@ enum rsc_table_entries {
 	RSC_TABLE_NUM_ENTRY
 };
 
+METAL_PACKED_BEGIN
+struct ept_info {
+	char name[RPMSG_NAME_SIZE];
+	uint32_t addr;
+	uint32_t dest_addr;
+} METAL_PACKED_END;
+
+#define MAX_NUM_OF_EPTS 64
+
+METAL_PACKED_BEGIN
+struct fw_rsc_ept {
+	uint32_t type;
+	uint32_t num_of_epts;
+	struct ept_info endpoints[MAX_NUM_OF_EPTS];
+} METAL_PACKED_END;
+
 struct fw_resource_table {
 	unsigned int ver;
 	unsigned int num;
 	unsigned int reserved[2];
 	unsigned int offset[RSC_TABLE_NUM_ENTRY];
 
+	struct fw_rsc_ept ept_table;
 #if (CONFIG_OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF > 0)
 	struct fw_rsc_vdev vdev;
 	struct fw_rsc_vdev_vring vring0;

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.h
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.h
@@ -48,6 +48,8 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device **vdev)
 int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev);
 #endif
 
+extern struct rpmsg_virtio_device rvdev;
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/ipc/rpmsg_service/rpmsg_service.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_service.c
@@ -25,7 +25,7 @@ static struct virtio_device *vdev;
 #else
 static struct virtio_device vdev;
 #endif
-static struct rpmsg_virtio_device rvdev;
+struct rpmsg_virtio_device rvdev;
 static struct metal_io_region *io;
 static bool ep_crt_started;
 
@@ -93,7 +93,7 @@ static void ns_bind_cb(struct rpmsg_device *rdev,
 
 #endif
 
-static int rpmsg_service_init(const struct device *dev)
+int rpmsg_service_init(const struct device *dev)
 {
 	int32_t err;
 


### PR DESCRIPTION
1. 在 rsctable 中添加 RSC_VENDOR_EPT_TABLE 项，用于记录 host 和 remote 之间绑定的 endpoint 列表
2. 增加 SYSTEM_RESET 状态，该状态说明 host 已经重启过了，因此需要在 remote 侧重新初始化 virtqueue 中的几个指针。