### PR TITLE
rpmsg_backend: clear reserved bit after the reset work is completed

### DIFF
--- a/boards/arm64/qemu_cortex_a53/qemu_cortex_a53_remote.dts
+++ b/boards/arm64/qemu_cortex_a53/qemu_cortex_a53_remote.dts
@@ -50,10 +50,9 @@
 	};
 
 	soc {
-
 		ipc_shm0: memory@70000000 {
 			compatible = "mmio-sram";
-			reg = <0 0x70000000 0 0x30000>;
+			reg = <0 0x70000000 0 0x100000>;
 		};
 
 		sram1: memory@7a000000 {


### PR DESCRIPTION
* Clear reserved[0] after the reset work is completed to let host know we're done.
* resize the shared memory area to consistent with Linux's memory nodes.